### PR TITLE
ユーザーに紐づくタスクの一覧を表示する

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @tasks = Task.where(user_id: @user.id)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @tasks = Task.where(user_id: @user.id)
+    @tasks = @user.tasks
   end
 
   def new

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,6 +2,7 @@ class Team < ApplicationRecord
   validates :name, presence: true, length: { maximum: 100 }
   validates :color, presence: true, color: :true
 
+  has_many :tasks
   has_many :user_teams
   has_many :users, through: :user_teams
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
 
   has_secure_password
 
+  has_many :tasks
   has_many :user_teams
   has_many :teams, through: :user_teams
 end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -9,6 +9,22 @@
   %b Email:
   = @user.email
 
+%table
+  %thead
+    %tr
+      %th Task ID
+      %th Title
+      %th Description
+
+  %tbody
+    - @tasks.each do |task|
+      %tr
+        %td= task.id
+        %td= task.title
+        %td= simple_format(task.description)
+
+%br
+
 = link_to 'Edit', edit_user_path(@user)
 \|
 = link_to 'Back', users_path

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,65 +1,100 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
+  let(:user) { create(:user) }
+
   describe "#index" do
     subject { get :index }
 
-    let(:task) { create(:task) }
+    context 'ログインしている時' do
+      let(:task) { create(:task) }
 
-    it do
-      is_expected.to have_http_status(:ok)
-      expect(assigns(:tasks)).to contain_exactly task
+      before { log_in user }
+
+      it do
+        is_expected.to have_http_status(:ok)
+        expect(assigns(:tasks)).to contain_exactly task
+      end
     end
+
+    context 'ログインしていないとき' do
+      it { is_expected.to redirect_to root_path }
+    end
+
   end
 
   describe "#show" do
     subject { get :show, params: { id: task_id } }
 
-    context 'when id is valid' do
-      let(:task) { create(:task) }
-      let(:task_id) { task.id }
+    let(:task) { create(:task) }
+    let(:task_id) { task.id }
 
-      it do
-        is_expected.to have_http_status(:ok)
-        expect(assigns(:task)).to eq task
+    context 'ログインしている時' do
+      before { log_in user }
+
+      context 'when id is valid' do
+        it do
+          is_expected.to have_http_status(:ok)
+          expect(assigns(:task)).to eq task
+        end
+      end
+
+      context 'when id is invalid' do
+        let(:task_id) { 'aaa' }
+
+        it { expect{subject}.to raise_error ActiveRecord::RecordNotFound }
       end
     end
 
-    context 'when id is invalid' do
-      let(:task_id) { 'aaa' }
-
-      it { expect{subject}.to raise_error ActiveRecord::RecordNotFound }
+    context 'ログインしていない時' do
+      it { is_expected.to redirect_to root_path }
     end
   end
 
   describe "#new" do
     subject { get :new }
 
-    it do
-      is_expected.to have_http_status(:ok)
-      expect(assigns(:task).class).to eq Task
+    context 'ログインしている時' do
+      before { log_in user }
+
+      it do
+        is_expected.to have_http_status(:ok)
+        expect(assigns(:task).class).to eq Task
+      end
+    end
+
+    context 'ログインしていない時' do
+      it { is_expected.to redirect_to root_path }
     end
   end
 
   describe "#create" do
-    subject { proc { post :create, params: { task: task_params } } }
+    subject { post :create, params: { task: task_params } }
 
-    context "with valid params" do
-      let(:task_params) { attributes_for :task }
+    let(:task_params) { attributes_for :task }
 
-      it "creates a new task" do
-        is_expected.to change { Task.count }.from(0).to(1)
-        expect(response).to redirect_to(Task.last)
+    context 'ログインしている時' do
+      before { log_in user }
+
+      context "with valid params" do
+        it "creates a new task" do
+          expect{ subject }.to change { Task.count }.from(0).to(1)
+          is_expected.to redirect_to(Task.last)
+        end
+      end
+
+      context "with invalid params" do
+        let(:task_params) { attributes_for :task, title: "" }
+
+        it do
+          expect{ subject }.not_to change { Task.count }
+          is_expected.to render_template :new
+        end
       end
     end
 
-    context "with invalid params" do
-      let(:task_params) { attributes_for :task, title: "" }
-
-      it do
-        is_expected.not_to change { Task.count }
-        expect(response).to render_template :new
-      end
+    context 'ログインしていない時' do
+      it { is_expected.to redirect_to root_path }
     end
   end
 end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe TasksController, type: :controller do
 
       context "with valid params" do
         it "creates a new task" do
-          expect{ subject }.to change { Task.count }.from(0).to(1)
+          expect{ subject }.to change { Task.count }.by(1)
           is_expected.to redirect_to(Task.last)
         end
       end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TasksController, type: :controller do
       end
     end
 
-    context 'ログインしていないとき' do
+    context 'ログインしていない時' do
       it { is_expected.to redirect_to root_path }
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -22,14 +22,22 @@ RSpec.describe UsersController, type: :controller do
 
   describe "#show" do
     subject { get :show, params: { id: user.id } }
-
     let(:user) { create :user }
-    let(:task) { create :task, { user_id: user.id } }
 
-    it do
-      is_expected.to have_http_status(:ok)
-      expect(assigns(:user)).to eq user
-      expect(assigns(:tasks)).to eq [task]
+    context 'ログインしている時'do
+      let(:task) { create :task, { user_id: user.id } }
+
+      before { log_in user }
+
+      it do
+        is_expected.to have_http_status(:ok)
+        expect(assigns(:user)).to eq user
+        expect(assigns(:tasks)).to eq [task]
+      end
+    end
+
+    context 'ログインしていないとき' do
+      it { is_expected.to redirect_to root_path }
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,19 +23,13 @@ RSpec.describe UsersController, type: :controller do
   describe "#show" do
     subject { get :show, params: { id: user.id } }
 
-    let(:user) { create(:user) }
+    let(:user) { create :user }
+    let(:task) { create :task, { user_id: user.id } }
 
-    context 'ログインしている時' do
-      before { log_in user }
-
-      it do
-        is_expected.to have_http_status(:ok)
-        expect(assigns(:user)).to eq user
-      end
-    end
-
-    context 'ログインしていない時' do
-      it { is_expected.to redirect_to root_path }
+    it do
+      is_expected.to have_http_status(:ok)
+      expect(assigns(:user)).to eq user
+      expect(assigns(:tasks)).to eq [task]
     end
   end
 


### PR DESCRIPTION
## 目的
users/show/:id でユーザーに紐づくタスクの一覧を表示できるようにする

## 内容
変更したのは
- app/controllers/users_controller.rb
- app/views/users/show.html.haml
- spec/controllers/users_controller_spec.rb
- app/models/user.rb
- app/models/team.rb