### PR TITLE
task登録時にログインユーザーのIDを取得する＆チームを選択できるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
   before_action :set_task, only: :show
+  before_action :set_user, only: :new
 
   def index
     @tasks = Task.all
@@ -10,10 +11,14 @@ class TasksController < ApplicationController
 
   def new
     @task = Task.new
+    # @teams = current_user.teams
+    @teams = @user.teams
+
   end
 
   def create
     @task = Task.new(task_params)
+    @task.user_id = current_user.id
 
     if @task.save
       redirect_to @task, notice: 'task was successfully created.'
@@ -28,7 +33,11 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
   end
 
+  def set_user
+    @user = current_user
+  end
+
   def task_params
-    params.require(:task).permit(:title, :description, :user_id, :team_id, :state)
+    params.require(:task).permit(:title, :description, :team_id, :state)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,8 +14,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
-    @task.user_id = current_user.id
+    @task = Task.new task_params.merge(user: current_user)
 
     if @task.save
       redirect_to @task, notice: 'task was successfully created.'

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,5 @@
 class TasksController < ApplicationController
   before_action :set_task, only: :show
-  before_action :set_user, only: :new
 
   def index
     @tasks = Task.all
@@ -11,9 +10,7 @@ class TasksController < ApplicationController
 
   def new
     @task = Task.new
-    # @teams = current_user.teams
-    @teams = @user.teams
-
+    @teams = current_user.teams
   end
 
   def create
@@ -31,10 +28,6 @@ class TasksController < ApplicationController
 
   def set_task
     @task = Task.find(params[:id])
-  end
-
-  def set_user
-    @user = current_user
   end
 
   def task_params

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,8 +3,8 @@ class Task < ApplicationRecord
   validates :description, presence: true, length: { maximum: 10000 }
   validates :state, presence: true
 
-  has_one :user
-  has_one :team
+  belongs_to :user
+  belongs_to :team
 
   enum state: { registered: 0, assigned: 1, completed: 2 }
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -7,7 +7,7 @@ class Team < ApplicationRecord
   has_many :users, through: :user_teams
 
   DEFAULT_COLORS = { red: '#ef5b3e', pink: '#ff658b', orange: '#ff9933',
-  yellow: '#eec400', blue: '#40bbef', green: '#2fc3a7', black: '#333333' }
+                     yellow: '#eec400', blue: '#40bbef', green: '#2fc3a7', black: '#333333' }
 
   DEFAULT_COLOR = DEFAULT_COLORS[:green]
 end

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -13,11 +13,8 @@
     = f.label :description
     = f.text_area :description
   .field
-    = f.label :user_id
-    = f.text_field :user_id
-  .field
     = f.label :team_id
-    = f.text_field :team_id
+    = f.select :team_id, @teams.map { |t| [t.name, t.id]  }
   .field
     = f.label :state
     = f.select :state, Task.states.keys.map {|k| [k, k]}

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -1,7 +1,7 @@
 %h1 Top
 
 - if logged_in?
-  %p= link_to 'Users'
+  %p= link_to 'Users', users_path
 
   %p= link_to 'Log Out', logout_path
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -27,4 +27,6 @@
 
 = link_to 'Edit', edit_user_path(@user)
 \|
+= link_to 'Todoの登録', new_task_path
+\|
 = link_to 'Back', users_path

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -46,23 +46,14 @@ RSpec.describe TasksController, type: :controller do
       context 'when id is invalid' do
         let(:task_id) { 'aaa' }
 
-        it { expect{subject}.to raise_error ActiveRecord::RecordNotFound }
-      end
-    end
-
-    context 'ログインしていない時' do
-      it { is_expected.to redirect_to root_path }
+      it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
     end
   end
 
   describe "#new" do
     subject { get :new }
 
-    # let(:team1) { create(:team) }
-    # let(:team2) { create(:team) }
-    # let(:user) { create(:user, teams: [team1, team2])}
-
-    let(:user) { create(:user, teams: create_list(:team, 2))}
+    let(:user) { create(:user, teams: create_list(:team, 2)) }
 
     before { log_in user }
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -58,13 +58,18 @@ RSpec.describe TasksController, type: :controller do
   describe "#new" do
     subject { get :new }
 
-    let(:user) { create(:user) }
+    # let(:team1) { create(:team) }
+    # let(:team2) { create(:team) }
+    # let(:user) { create(:user, teams: [team1, team2])}
+
+    let(:user) { create(:user, teams: create_list(:team, 2))}
 
     before { log_in user }
 
     it do
       is_expected.to have_http_status(:ok)
       expect(assigns(:task).class).to eq Task
+      expect(assigns(:teams)).to eq user.teams
     end
   end
 
@@ -78,23 +83,19 @@ RSpec.describe TasksController, type: :controller do
     context "with valid params" do
       let(:task_params) { attributes_for :task }
 
-    context 'ログインしている時' do
-      before { log_in user }
-
-      context "with valid params" do
-        it "creates a new task" do
-          expect{ subject }.to change { Task.count }.by(1)
-          is_expected.to redirect_to(Task.last)
-        end
+      it "creates a new task" do
+        is_expected.to change { Task.count }.by(1)
+        expect(response).to redirect_to(Task.last)
+        expect(assigns(:task).user_id).to eq user.id
       end
 
       context "with invalid params" do
         let(:task_params) { attributes_for :task, title: "" }
 
-        it do
-          expect{ subject }.not_to change { Task.count }
-          is_expected.to render_template :new
-        end
+      it do
+        is_expected.not_to change { Task.count }
+        expect(response).to render_template :new
+        expect(assigns(:task).user_id).to eq user.id
       end
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe TasksController, type: :controller do
     context 'ログインしていない時' do
       it { is_expected.to redirect_to root_path }
     end
-
   end
 
   describe "#show" do
@@ -42,11 +41,11 @@ RSpec.describe TasksController, type: :controller do
       end
     end
 
-      context 'when id is invalid' do
-        let(:task_id) { 'aaa' }
+    context 'when id is invalid' do
+    let(:task_id) { 'aaa' }
 
-      it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
-    end
+    it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
+  end
   end
 
   describe "#new" do
@@ -74,10 +73,9 @@ RSpec.describe TasksController, type: :controller do
       before { log_in user }
 
       context "with valid params" do
-
         it "creates a new task" do
           aggregate_failures do
-            expect{ subject }.to change { Task.count }.by(1)
+            expect { subject }.to change { Task.count }.by(1)
             expect(response).to redirect_to(Task.last)
             expect(assigns(:task).user_id).to eq user.id
           end
@@ -88,7 +86,7 @@ RSpec.describe TasksController, type: :controller do
         let(:task_params) { attributes_for :task, team_id: team.id, title: "" }
 
         it do
-          expect{ subject }.not_to change { Task.count }
+          expect { subject }.not_to change { Task.count }
           expect(response).to render_template :new
           expect(assigns(:task).user_id).to eq user.id
         end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -6,15 +6,14 @@ RSpec.describe TasksController, type: :controller do
   describe "#index" do
     subject { get :index }
 
-    context 'ログインしている時' do
-      let(:task) { create(:task) }
+    let(:user) { create(:user) }
+    let(:task) { create(:task) }
 
-      before { log_in user }
+    before { log_in user }
 
-      it do
-        is_expected.to have_http_status(:ok)
-        expect(assigns(:tasks)).to contain_exactly task
-      end
+    it do
+      is_expected.to have_http_status(:ok)
+      expect(assigns(:tasks)).to contain_exactly task
     end
 
     context 'ログインしていない時' do
@@ -26,8 +25,13 @@ RSpec.describe TasksController, type: :controller do
   describe "#show" do
     subject { get :show, params: { id: task_id } }
 
-    let(:task) { create(:task) }
-    let(:task_id) { task.id }
+    let(:user) { create(:user) }
+
+    before { log_in user }
+
+    context 'when id is valid' do
+      let(:task) { create(:task) }
+      let(:task_id) { task.id }
 
     context 'ログインしている時' do
       before { log_in user }
@@ -54,24 +58,25 @@ RSpec.describe TasksController, type: :controller do
   describe "#new" do
     subject { get :new }
 
-    context 'ログインしている時' do
-      before { log_in user }
+    let(:user) { create(:user) }
 
-      it do
-        is_expected.to have_http_status(:ok)
-        expect(assigns(:task).class).to eq Task
-      end
-    end
+    before { log_in user }
 
-    context 'ログインしていない時' do
-      it { is_expected.to redirect_to root_path }
+    it do
+      is_expected.to have_http_status(:ok)
+      expect(assigns(:task).class).to eq Task
     end
   end
 
   describe "#create" do
     subject { post :create, params: { task: task_params } }
 
-    let(:task_params) { attributes_for :task }
+    let(:user) { create(:user) }
+
+    before { log_in user }
+
+    context "with valid params" do
+      let(:task_params) { attributes_for :task }
 
     context 'ログインしている時' do
       before { log_in user }

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,20 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
-  let(:user) { create(:user) }
+  # let(:user) { create(:user) }
 
   describe "#index" do
     subject { get :index }
 
-    let(:task) { create(:task, :with_user_and_team) }
+    context 'ログインしている時' do
+      let(:task) { create(:task, :with_user_and_team) }
 
-    before do
-      log_in task.user
-    end
+      before do
+        log_in task.user
+      end
 
-    it do
-      is_expected.to have_http_status(:ok)
-      expect(assigns(:tasks)).to contain_exactly task
+      it do
+        is_expected.to have_http_status(:ok)
+        expect(assigns(:tasks)).to contain_exactly task
+      end
     end
 
     context 'ログインしていない時' do
@@ -38,6 +40,7 @@ RSpec.describe TasksController, type: :controller do
         is_expected.to have_http_status(:ok)
         expect(assigns(:task)).to eq task
       end
+    end
 
       context 'when id is invalid' do
         let(:task_id) { 'aaa' }
@@ -67,25 +70,28 @@ RSpec.describe TasksController, type: :controller do
     let!(:team) { create(:team, users: [user]) }
     let(:task_params) { attributes_for :task, team_id: team.id }
 
-    before { log_in user }
+    context 'ログインしている時' do
+      before { log_in user }
 
-    context "with valid params" do
+      context "with valid params" do
 
-      it "creates a new task" do
-        aggregate_failures do
-          is_expected.to change { Task.count }.by(1)
-          expect(response).to redirect_to(Task.last)
-          expect(assigns(:task).user_id).to eq user.id
+        it "creates a new task" do
+          aggregate_failures do
+            expect{ subject }.to change { Task.count }.by(1)
+            expect(response).to redirect_to(Task.last)
+            expect(assigns(:task).user_id).to eq user.id
+          end
         end
       end
 
-    context "with invalid params" do
-      let(:task_params) { attributes_for :task, team_id: team.id, title: "" }
+      context "with invalid params" do
+        let(:task_params) { attributes_for :task, team_id: team.id, title: "" }
 
-      it do
-        is_expected.not_to change { Task.count }
-        expect(response).to render_template :new
-        expect(assigns(:task).user_id).to eq user.id
+        it do
+          expect{ subject }.not_to change { Task.count }
+          expect(response).to render_template :new
+          expect(assigns(:task).user_id).to eq user.id
+        end
       end
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,17 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
-  # let(:user) { create(:user) }
-
   describe "#index" do
     subject { get :index }
 
     context 'ログインしている時' do
-      let(:task) { create(:task, :with_user_and_team) }
+      let(:task) { create(:task) }
 
-      before do
-        log_in task.user
-      end
+      before { log_in task.user }
 
       it do
         is_expected.to have_http_status(:ok)
@@ -27,7 +23,7 @@ RSpec.describe TasksController, type: :controller do
   describe "#show" do
     subject { get :show, params: { id: task_id } }
 
-    let(:task) { create(:task, :with_user_and_team) }
+    let(:task) { create(:task) }
     let(:task_id) { task.id }
 
     before do
@@ -42,10 +38,10 @@ RSpec.describe TasksController, type: :controller do
     end
 
     context 'when id is invalid' do
-    let(:task_id) { 'aaa' }
+      let(:task_id) { 'aaa' }
 
-    it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
-  end
+      it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
+    end
   end
 
   describe "#new" do
@@ -66,19 +62,17 @@ RSpec.describe TasksController, type: :controller do
     subject { post :create, params: { task: task_params } }
 
     let(:user) { create(:user) }
-    let!(:team) { create(:team, users: [user]) }
+    let(:team) { create(:team, users: [user]) }
     let(:task_params) { attributes_for :task, team_id: team.id }
 
     context 'ログインしている時' do
       before { log_in user }
 
       context "with valid params" do
-        it "creates a new task" do
-          aggregate_failures do
-            expect { subject }.to change { Task.count }.by(1)
-            expect(response).to redirect_to(Task.last)
-            expect(assigns(:task).user_id).to eq user.id
-          end
+        it :aggregate_failures do
+          expect { subject }.to change { Task.count }.by(1)
+          expect(response).to redirect_to(Task.last)
+          expect(assigns(:task).user_id).to eq user.id
         end
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UsersController, type: :controller do
 
     let(:user) { create(:user, :with_team_and_task) }
 
-    context 'ログインしている時'do
+    context 'ログインしている時' do
       before do
         log_in user
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#index" do
     subject { get :index }
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user_with_team_and_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }
@@ -23,7 +23,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#show" do
     subject { get :show, params: { id: user.id } }
 
-    let(:user) { create(:user, :with_team_and_task) }
+    let(:user) { create(:user_with_team_and_tasks) }
 
     context 'ログインしている時' do
       before do
@@ -33,7 +33,7 @@ RSpec.describe UsersController, type: :controller do
       it :aggregate_failures do
         is_expected.to have_http_status(:ok)
         expect(assigns(:user)).to eq user
-        expect(assigns(:tasks)).to eq user.tasks
+        expect(assigns(:tasks)).to match_array(user.tasks)
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#edit" do
     subject { get :edit, params: { id: user.id } }
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user_with_team_and_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }
@@ -94,7 +94,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#update" do
     subject { put :update, params: { id: user.id, user: user_params } }
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user_with_team_and_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }
@@ -133,7 +133,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#destroy" do
     subject { delete :destroy, params: { id: user.id } }
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user_with_team_and_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#index" do
     subject { get :index }
 
-    let(:user) { create(:user_with_team_and_tasks) }
+    let(:user) { create(:user_with_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }
@@ -23,7 +23,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#show" do
     subject { get :show, params: { id: user.id } }
 
-    let(:user) { create(:user_with_team_and_tasks) }
+    let(:user) { create(:user_with_tasks) }
 
     context 'ログインしている時' do
       before do
@@ -54,7 +54,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#edit" do
     subject { get :edit, params: { id: user.id } }
 
-    let(:user) { create(:user_with_team_and_tasks) }
+    let(:user) { create(:user_with_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }
@@ -94,7 +94,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#update" do
     subject { put :update, params: { id: user.id, user: user_params } }
 
-    let(:user) { create(:user_with_team_and_tasks) }
+    let(:user) { create(:user_with_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }
@@ -133,7 +133,7 @@ RSpec.describe UsersController, type: :controller do
   describe "#destroy" do
     subject { delete :destroy, params: { id: user.id } }
 
-    let(:user) { create(:user_with_team_and_tasks) }
+    let(:user) { create(:user_with_tasks) }
 
     context 'ログインしている時' do
       before { log_in user }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -22,17 +22,18 @@ RSpec.describe UsersController, type: :controller do
 
   describe "#show" do
     subject { get :show, params: { id: user.id } }
-    let(:user) { create :user }
+
+    let(:user) { create(:user, :with_team_and_task) }
 
     context 'ログインしている時'do
-      let(:task) { create :task, { user_id: user.id } }
+      before do
+        log_in user
+      end
 
-      before { log_in user }
-
-      it do
+      it :aggregate_failures do
         is_expected.to have_http_status(:ok)
         expect(assigns(:user)).to eq user
-        expect(assigns(:tasks)).to eq [task]
+        expect(assigns(:tasks)).to eq user.tasks
       end
     end
 

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -5,5 +5,14 @@ FactoryBot.define do
     user_id 1
     team_id 1
     state 'registered'
+
+    trait :with_user_and_team do
+      before(:create) do |task, _|
+        user = create(:user)
+        team = create(:team, users: [user])
+        task.user = user
+        task.team = team
+      end
+    end
   end
 end

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -2,17 +2,8 @@ FactoryBot.define do
   factory :task do
     title '資料の作成'
     description 'エンジニアミーティング用の資料を作成する'
-    user_id 1
-    team_id 1
+    association :user
+    association :team
     state 'registered'
-
-    trait :with_user_and_team do
-      before(:create) do |task, _|
-        user = create(:user)
-        team = create(:team, users: [user])
-        task.user = user
-        task.team = team
-      end
-    end
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,14 +5,13 @@ FactoryBot.define do
     password "TEST_PASSWORD"
     password_confirmation "TEST_PASSWORD"
 
-    factory :user_with_team_and_tasks do
+    factory :user_with_tasks do
       transient do
         tasks_count 1
       end
 
       after(:create) do |user, evaluator|
-        team = create(:team)
-        create_list(:task, evaluator.tasks_count, user: user, team: team)
+        create_list(:task, evaluator.tasks_count, user: user)
       end
     end
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,10 +5,14 @@ FactoryBot.define do
     password "TEST_PASSWORD"
     password_confirmation "TEST_PASSWORD"
 
-    trait :with_team_and_task do
-      after(:create) do |user, _|
-        team = create(:team, users: [user])
-        task = create(:task, user: user, team: team)
+    factory :user_with_team_and_tasks do
+      transient do
+        tasks_count 1
+      end
+
+      after(:create) do |user, evaluator|
+        team = create(:team)
+        create_list(:task, evaluator.tasks_count, user: user, team: team)
       end
     end
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,5 +4,12 @@ FactoryBot.define do
     sequence(:email) { |n| "TEST#{n}@example.com" }
     password "TEST_PASSWORD"
     password_confirmation "TEST_PASSWORD"
+
+    trait :with_team_and_task do
+      after(:create) do |user, _|
+        team = create(:team, users: [user])
+        task = create(:task, user: user, team: team)
+      end
+    end
   end
 end

--- a/spec/models/create_team_decorator_spec.rb
+++ b/spec/models/create_team_decorator_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe CreateTeamDecorator, type: :model do
       let(:attributes) { {} }
 
       it do
-        expect{subject}.to change { Team.count }.by(1).and \
+        expect { subject }.to change { Team.count }.by(1).and \
           change { User.count }.by(1).and \
-          change { UserTeam.count }.by(1)
+            change { UserTeam.count }.by(1)
         is_expected.to be_truthy
       end
     end
@@ -26,7 +26,7 @@ RSpec.describe CreateTeamDecorator, type: :model do
       before { allow_any_instance_of(Team).to receive(:save!).and_raise() }
 
       it do
-        expect{ subject }.not_to change { User.count }
+        expect { subject }.not_to change { User.count }
         is_expected.to be_falsey
       end
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,52 +2,56 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe '#valid?' do
+    let(:user) { create(:user) }
+    let!(:team) { create(:team, users: [user]) }
+    let(:valid_params) { { user_id: user.id, team_id: team.id } }
+
     subject { build :task, attributes }
 
     context 'タスクの登録に成功するとき' do
-      let(:attributes) { {} }
+      let(:attributes) { valid_params }
 
       it { is_expected.to be_valid }
     end
 
     context 'titleが存在しないとき' do
-      let(:attributes) { { title: '' } }
+      let(:attributes) { valid_params.merge(title: '') }
 
       it { is_expected.to be_invalid }
     end
 
     context 'titleが100文字のとき' do
-      let(:attributes) { { title: 'a' * 100 } }
+      let(:attributes) { valid_params.merge(title: 'a' * 100) }
 
       it { is_expected.to be_valid }
     end
 
     context 'titleが101文字のとき' do
-      let(:attributes) { { title: 'a' * 101 } }
+      let(:attributes) { valid_params.merge(title: 'a' * 101) }
 
       it { is_expected.to be_invalid }
     end
 
     context 'descriptionが存在しないとき' do
-      let(:attributes) { { description: '' } }
+      let(:attributes) { valid_params.merge(description: '') }
 
       it { is_expected.to be_invalid }
     end
 
     context 'descriptionが10000文字のとき' do
-      let(:attributes) { { description: 'a' * 10000 } }
+      let(:attributes) { valid_params.merge(description: 'a' * 10000) }
 
       it { is_expected.to be_valid }
     end
 
     context 'descriptionが10001文字のとき' do
-      let(:attributes) { { description: 'a' * 10001 } }
+      let(:attributes) { valid_params.merge(description: 'a' * 10001) }
 
       it { is_expected.to be_invalid }
     end
 
     context 'stateが存在しないとき' do
-      let(:attributes) { { state: '' } }
+      let(:attributes) { valid_params.merge(state: '') }
 
       it { is_expected.to be_invalid }
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Task, type: :model do
   describe '#valid?' do
     let(:user) { create(:user) }
-    let!(:team) { create(:team, users: [user]) }
+    let(:team) { create(:team, users: [user]) }
     let(:valid_params) { { user_id: user.id, team_id: team.id } }
 
     subject { build :task, attributes }


### PR DESCRIPTION
## 目的
- task登録時にログインユーザーのIDを手入力していたのを、カレントユーザーから取得する
- task登録時にユーザーに紐づいているチームから選択できるようにする

## 内容
taskの `user_id`を `current_user.id`で取得する