### PR TITLE
タスクの期限とやる日のモデルの関連付けと、モデルのテストを追加

### DIFF
--- a/app/models/completion_date.rb
+++ b/app/models/completion_date.rb
@@ -1,2 +1,4 @@
 class CompletionDate < ApplicationRecord
+  validates :begin_at, presence: true
+  belongs_to :task
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,8 @@ class Task < ApplicationRecord
   validates :description, presence: true, length: { maximum: 10000 }
   validates :state, presence: true
 
+  has_one :task_due_date
+  has_one :completion_date
   belongs_to :user
   belongs_to :team
 

--- a/app/models/task_due_date.rb
+++ b/app/models/task_due_date.rb
@@ -1,2 +1,4 @@
 class TaskDueDate < ApplicationRecord
+  validates :end_at, presence: true
+  belongs_to :task
 end

--- a/spec/factories/completion_date_factory.rb
+++ b/spec/factories/completion_date_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :completion_date do
+    begin_at '2018-06-25 08:37:11'
+    association :task
+  end
+end

--- a/spec/factories/task_due_date_factory.rb
+++ b/spec/factories/task_due_date_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :task_due_date do
+    end_at '2018-06-25 08:37:11'
+    association :task
+  end
+end

--- a/spec/models/completion_date_spec.rb
+++ b/spec/models/completion_date_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe CompletionDate, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#valid?' do
+    subject { build :completion_date, attributes }
+
+    context 'dateが正しく入力された時' do
+      let(:attributes) { {} }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'dateが入力されなかった時' do
+      let(:attributes) { { begin_at: "" } }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context 'dateの値が不正な時' do
+      let(:attributes) { { begin_at: "aaa" } }
+
+      it { is_expected.to be_invalid }
+    end
+  end
 end

--- a/spec/models/task_due_date_spec.rb
+++ b/spec/models/task_due_date_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe TaskDueDate, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#valid?' do
+    subject { build :task_due_date, attributes }
+
+    context 'dateが正しく入力された時' do
+      let(:attributes) { {} }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'dateが入力されなかった時' do
+      let(:attributes) { { end_at: "" } }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context 'dateの値が不正な時' do
+      let(:attributes) { { end_at: "aaa" } }
+
+      it { is_expected.to be_invalid }
+    end
+  end
 end


### PR DESCRIPTION
## 目的
タスク登録の時に、「期限」と「やるひ」を一緒に登録できるようにするための準備

## 内容
- `task_due_date`と`completion_date`の関連付けと、validationを追加
- ↑のテストを作成